### PR TITLE
SerialPort's open is asynchronous,treat it as such

### DIFF
--- a/lib/sphero.js
+++ b/lib/sphero.js
@@ -38,10 +38,15 @@ module.exports = function() {
     }
   };
 
-  _sphero.open = function(device) {
+  _sphero.open = function(device, callback) {
     _serialPort = new serialPort.SerialPort(device, {
       parser:responseParser.spheroResponseParser()
-    });
+    }, true, function(err){ 
+      if (err){
+        if (callback && typeof(callback) == 'function'){
+          callback(err);
+        }
+      }});
 
     _serialPort.on('open', function() {
       _serialPort.on('data', function(packet) {
@@ -56,19 +61,23 @@ module.exports = function() {
         }
       });
 
+      _serialPort.on('close', function() {
+        _sphero.emit('close');
+      });
+      _serialPort.on('end', function() {
+        _sphero.emit('end');
+      });
+      _serialPort.on('error', function(error) {
+        _sphero.emit('error', error);
+      });
+      _serialPort.on('oob', function(packet) {
+        _sphero.emit('oob', packet);
+      });
+
       _sphero.emit('open');
-    });
-    _serialPort.on('close', function() {
-      _sphero.emit('close');
-    });
-    _serialPort.on('end', function() {
-      _sphero.emit('end');
-    });
-    _serialPort.on('error', function(error) {
-      _sphero.emit('error', error);
-    });
-    _serialPort.on('oob', function(packet) {
-      _sphero.emit('oob', packet);
+      if (callback && typeof(callback) == 'function'){
+        callback(null);
+      }
     });
     return _sphero;
   };


### PR DESCRIPTION
This is the source of the 'Serial port is not open' error I was running in to at RobotsConf. The SerialPort's open is an asynchronous, so we must wait for it before claiming the robot's connected. This will have an accompanying cylon-sphero PR. Thanks for all the awesome work!
